### PR TITLE
Add runtime settings overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,18 +3,40 @@
 <head>
 	<meta charset="UTF-8">
 	<title>Globe</title>
-	<style type="text/css">
-		html, body, canvas {
-			overflow: hidden;
-			margin: 0;
-			padding: 0;
-			width: 100%;
-			height: 100%;
-		}
-	</style>
+        <style type="text/css">
+                html, body, canvas {
+                        overflow: hidden;
+                        margin: 0;
+                        padding: 0;
+                        width: 100%;
+                        height: 100%;
+                }
+                /* Overlay container for runtime settings */
+                #settingsOverlay {
+                        position: absolute;
+                        top: 10px;
+                        right: 10px;
+                        z-index: 1000;
+                        background: rgba(255, 255, 255, 0.8);
+                        padding: 10px;
+                        font-family: sans-serif;
+                }
+
+                #settingsOverlay label {
+                        display: block;
+                        margin-bottom: 5px;
+                }
+        </style>
 </head>
 <body>
-	<canvas id="aux"></canvas>
+        <div id="settingsOverlay">
+                <label>Height Scale <input type="range" id="heightScale" min="0" max="0.2" step="0.01" value="0.05"></label>
+                <label>Ice Cap Latitude <input type="range" id="iceCapLat" min="0" max="1" step="0.05" value="0.75"></label>
+                <label>Ice Cap Level <input type="range" id="iceCapLvl" min="0" max="0.1" step="0.005" value="0.025"></label>
+                <label>Transition Range <input type="range" id="iceCapRange" min="0" max="0.1" step="0.005" value="0.05"></label>
+                <button id="applySettings">Update</button>
+        </div>
+        <canvas id="aux"></canvas>
 	<canvas id="main"></canvas>
 	<canvas id="gui"></canvas>
 	<script src="three.js"></script>


### PR DESCRIPTION
## Summary
- add HTML overlay with sliders to tweak globe parameters
- refactor globe generation into `generateGlobe()` so the globe can be rebuilt
- hook up Update button to regenerate the globe with new settings
- document new code with inline comments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687b7b1202b48328a8debe16b6635763