### PR TITLE
Improve drag controls for globe rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ This starts a local server at `http://localhost:3000` that serves the project fi
 
 ## Controls
 
-- **Rotate:** click and drag the mouse on the canvas.
-- **Zoom:** use the mouse wheel to zoom the camera in and out.
+ - **Rotate:** click and drag (or touch and drag) the canvas.
+ - **Zoom:** use the mouse wheel to zoom the camera in and out.

--- a/globe.js
+++ b/globe.js
@@ -93,21 +93,22 @@ scene.add(light);
 var ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
 scene.add(ambientLight);
 
-// Track current mouse position
+// Track current pointer position
 var mouse = { x: 0, y: 0 };
 // Flags for click-and-drag camera control
 var isDragging = false;
 var dragStart = { x: 0, y: 0 };
 
-// Start dragging when the user presses the mouse button on the canvas
-canvas.addEventListener("mousedown", function(event) {
+// Start dragging when the user presses on the canvas
+canvas.addEventListener("pointerdown", function(event) {
     isDragging = true;
     dragStart.x = event.clientX;
     dragStart.y = event.clientY;
+    canvas.setPointerCapture(event.pointerId);
 });
 
-// Rotate camera while dragging the mouse
-window.addEventListener("mousemove", function(event) {
+// Rotate camera while dragging the pointer
+canvas.addEventListener("pointermove", function(event) {
     mouse.x = event.clientX;
     mouse.y = event.clientY;
     if (isDragging) {
@@ -121,9 +122,10 @@ window.addEventListener("mousemove", function(event) {
     }
 });
 
-// Stop dragging on mouse release
-window.addEventListener("mouseup", function() {
+// Stop dragging when the pointer is released
+canvas.addEventListener("pointerup", function(event) {
     isDragging = false;
+    canvas.releasePointerCapture(event.pointerId);
 });
 
 // Zoom in/out with the mouse wheel


### PR DESCRIPTION
## Summary
- use pointer events for drag rotation and zoom with the mouse wheel
- update controls section in README

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687b83eb27048328b3ee1f7184cb0418