### PR TITLE
Fix first-person movement and add head height setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ This starts a local server at `http://localhost:3000` that serves the project fi
 
  - **Rotate:** click and drag (or touch and drag) the canvas.
  - **Zoom:** use the mouse wheel to zoom the camera in and out.
- - **First Person:** enable the "First Person View" checkbox to walk on the globe. Use WASD to move and the mouse to look around.
+- **First Person:** enable the "First Person View" checkbox to walk on the globe. Use WASD to move and the mouse to look around.
+- **Head Height:** adjust the "Head Height" input in the settings panel to control how high the camera sits above the ground when in first person view.

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
                 <label>Ice Cap Latitude <input type="range" id="iceCapLat" min="0" max="1" step="0.05" value="0.75"></label>
                 <label>Ice Cap Level <input type="range" id="iceCapLvl" min="0" max="0.1" step="0.005" value="0.025"></label>
                 <label>Transition Range <input type="range" id="iceCapRange" min="0" max="0.1" step="0.005" value="0.05"></label>
+                <label>Head Height <input type="number" id="headHeight" min="0" max="0.5" step="0.01" value="0.02"></label>
                 <label><input type="checkbox" id="firstPersonToggle"> First Person View</label>
                 <button id="applySettings">Update</button>
         </div>


### PR DESCRIPTION
## Summary
- add new "Head Height" input in the settings panel
- store head height on the player object
- use headHeight in first-person calculations
- compute forward direction relative to surface normal so you can move around the entire globe
- document new control in README

## Testing
- `npm install`
- `npm start` *(server launches)*

------
https://chatgpt.com/codex/tasks/task_e_687bf9b76f4c83288e4bdbdbdd54b367