### PR TITLE
Allow custom port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ npm start
 
 This starts a local server at `http://localhost:3000` that serves the project files. Open that URL in your browser to view the globe.
 
+To run the server on a different port, set the `PORT` environment variable or
+pass the desired port as a command line argument. See
+[docs/port.md](docs/port.md) for details.
+
 ## Controls
 
  - **Rotate:** click and drag (or touch and drag) the canvas.

--- a/docs/port.md
+++ b/docs/port.md
@@ -1,0 +1,31 @@
+# Running the Server on a Custom Port
+
+The server listens on port `3000` by default. You can override this using either
+an environment variable or a command line argument.
+
+## Using an Environment Variable
+
+Set the `PORT` environment variable when starting the server:
+
+```bash
+PORT=5000 npm start
+```
+
+## Using a Command Line Argument
+
+You can also specify the port directly after the script name:
+
+```bash
+node server.js 5000
+```
+
+`npm start` passes any additional arguments to `node`, so the following works as
+well:
+
+```bash
+npm start 5000
+```
+
+The server will check the command line argument first. If no argument is given,
+it falls back to the `PORT` environment variable and finally to the default
+`3000`.

--- a/server.js
+++ b/server.js
@@ -3,8 +3,12 @@ const express = require('express');
 const path = require('path');
 
 const app = express();
-// Default port is 3000 but can be overridden with the PORT env variable
-const PORT = process.env.PORT || 3000;
+// Determine which port to use. The server checks for a command line
+// argument first, then falls back to the PORT environment variable.
+// If neither are provided, it defaults to 3000.
+//   - Example CLI: `node server.js 5000`
+//   - Example env var: `PORT=5000 npm start`
+const PORT = process.argv[2] || process.env.PORT || 3000;
 
 // Serve static files from the current directory
 // Serve all files in this directory


### PR DESCRIPTION
## Summary
- add CLI argument support to choose port for server
- document custom port usage in new docs/port.md
- mention custom port option in README

## Testing
- `npm install`
- `node server.js 4001 & sleep 2; kill $!`
- `PORT=5002 node server.js & sleep 2; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_687bfc35cd848328a30f16961d90f276