### PR TITLE
Add auto-rotate toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ pass the desired port as a command line argument. See
 ## Controls
 
  - **Rotate:** click and drag (or touch and drag) the canvas.
- - **Zoom:** use the mouse wheel to zoom the camera in and out.
+- **Zoom:** use the mouse wheel to zoom the camera in and out.
 - **First Person:** enable the "First Person View" checkbox to walk on the globe. Use WASD to move and the mouse to look around.
 - **Head Height:** adjust the "Head Height" input in the settings panel to control how high the camera sits above the ground when in first person view.
+- **Auto Rotate:** uncheck the "Auto Rotate" box to stop the globe from spinning.
  - *First Person Note:* browsers only grant pointer lock (needed for looking around) when served from a web server. If you open `index.html` directly from your filesystem, the checkbox may not work.

--- a/globe.js
+++ b/globe.js
@@ -256,6 +256,10 @@ var cam = {
 
 // Toggle for switching between orbit and first person camera modes
 var firstPerson = false;
+// Controls whether the globe automatically rotates each frame
+var autoRotate = true;
+// Keep the JS toggle state in sync with the checkbox's initial setting
+autoRotate = document.getElementById('autoRotateToggle').checked;
 // Stores player orientation and position when in first person mode
 var player = {
     position: new THREE.Vector3(),
@@ -518,6 +522,11 @@ document.getElementById('firstPersonToggle').addEventListener('change', function
     }
 });
 
+// Enable or disable automatic rotation when the checkbox changes
+document.getElementById('autoRotateToggle').addEventListener('change', function() {
+    autoRotate = this.checked;
+});
+
 
 // Main render loop
 function draw() {
@@ -530,8 +539,11 @@ function draw() {
     guiTexture.needsUpdate = true;
     */
 
-    land.rotation.y += 0.0005;
-    ocean.rotation.y += 0.0005;
+    // Slowly spin the world unless auto-rotation is disabled
+    if (autoRotate) {
+        land.rotation.y += 0.0005;
+        ocean.rotation.y += 0.0005;
+    }
 
     if (firstPerson) {
         // Calculate orientation relative to the surface normal. The player

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
                 <label>Transition Range <input type="range" id="iceCapRange" min="0" max="0.1" step="0.005" value="0.05"></label>
                 <label>Head Height <input type="number" id="headHeight" min="0" max="0.5" step="0.01" value="0.02"></label>
                 <label><input type="checkbox" id="firstPersonToggle"> First Person View</label>
+                <label><input type="checkbox" id="autoRotateToggle" checked> Auto Rotate</label>
                 <button id="applySettings">Update</button>
         </div>
         <canvas id="aux"></canvas>


### PR DESCRIPTION
## Summary
- add "Auto Rotate" checkbox in overlay
- allow world rotation to be toggled via checkbox
- document new control in README

## Testing
- `npm install`
- `npm start` (terminated after showing the server started)

------
https://chatgpt.com/codex/tasks/task_e_687ca446e19c8328846cdb2f7fc85c9e