### PR TITLE
Use forward vector to spawn player

### DIFF
--- a/globe.js
+++ b/globe.js
@@ -118,11 +118,10 @@ canvas.addEventListener("pointermove", function(event) {
         // Rotate the player quaternion based on mouse movement. Yaw is applied
         // around the local Y axis (up) followed by pitch around the resulting
         // X axis. Using quaternions avoids gimbal lock entirely.
-        // Yaw is rotated around the player's up direction (local surface normal)
-        // so looking around works correctly even at the poles and avoids
-        // gimbal lock. The up axis is derived from the player's current
-        // position on the globe and normalized.
-        var upAxis = player.position.clone().normalize();
+        // Yaw is rotated around the player's current up vector rather than the
+        // world Y axis. Using the orientation's up direction keeps yaw working
+        // even when looking straight up or down, preventing gimbal lock.
+        var upAxis = new THREE.Vector3(0, 1, 0).applyQuaternion(player.rotation);
         var yawQuat = new THREE.Quaternion().setFromAxisAngle(
             upAxis,
             -event.movementX * 0.002

--- a/globe.js
+++ b/globe.js
@@ -539,11 +539,13 @@ document.getElementById('applySettings').addEventListener('click', function() {
 document.getElementById('firstPersonToggle').addEventListener('change', function() {
     firstPerson = this.checked;
     if (firstPerson) {
-        // Convert the current orbit orientation to spherical coordinates so
-        // the player spawns at the same location when switching modes.
-        var e = new THREE.Euler().setFromQuaternion(cam.rotation, 'YXZ');
-        var lon = e.y;           // rotation around the Y axis
-        var lat = -e.x;          // latitude measured from the equator
+        // Derive the player's spawn orientation from the camera quaternion.
+        // Computing the forward vector directly from the quaternion keeps the
+        // math in vector space and avoids gimbal lock issues that Euler angles
+        // can suffer from when looking straight up or down.
+        var forward = new THREE.Vector3(0, 0, -1).applyQuaternion(cam.rotation);
+        var lat = Math.asin(forward.y);            // latitude from forward vector
+        var lon = Math.atan2(forward.x, forward.z); // longitude around the Y axis
         var alt = getAlt(lon, lat).alt;
 
         // Position the player slightly above the surface based on headHeight.


### PR DESCRIPTION
## Summary
- compute lat/lon from the camera quaternion
- avoid creating an intermediate Euler to prevent gimbal lock

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687feb6534b483288a5457544a9fefd7