### PR TITLE
Add automatic port selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 npm start
 ```
 
-This starts a local server at `http://localhost:3000` that serves the project files. Open that URL in your browser to view the globe.
+When the server starts it automatically opens your default browser to the correct URL. It attempts to use port `3000` by default but will move to the next available port if `3000` is already in use.
 
 To run the server on a different port, set the `PORT` environment variable or
 pass the desired port as a command line argument. See

--- a/docs/port.md
+++ b/docs/port.md
@@ -1,7 +1,8 @@
 # Running the Server on a Custom Port
 
-The server listens on port `3000` by default. You can override this using either
-an environment variable or a command line argument.
+The server listens on port `3000` by default and will automatically move to the
+next available port if that one is already in use. You can override the starting
+port using either an environment variable or a command line argument.
 
 ## Using an Environment Variable
 
@@ -28,4 +29,5 @@ npm start 5000
 
 The server will check the command line argument first. If no argument is given,
 it falls back to the `PORT` environment variable and finally to the default
-`3000`.
+`3000`. Whichever port it ends up using, it will open your browser to that
+address once the server is ready.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "js_globe_gen",
       "version": "1.0.0",
       "dependencies": {
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "portfinder": "^1.0.37"
       }
     },
     "node_modules/accepts": {
@@ -28,6 +29,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -558,6 +565,42 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.37.tgz",
+      "integrity": "sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/portfinder/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "portfinder": "^1.0.37"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,6 +1,10 @@
 // Simple Express server to host the project locally
 const express = require('express');
 const path = require('path');
+// Utility to find the first open port starting from a base port
+const portfinder = require('portfinder');
+// We will spawn the platform-specific command to open the browser
+const { exec } = require('child_process');
 
 const app = express();
 // Determine which port to use. The server checks for a command line
@@ -8,12 +12,35 @@ const app = express();
 // If neither are provided, it defaults to 3000.
 //   - Example CLI: `node server.js 5000`
 //   - Example env var: `PORT=5000 npm start`
-const PORT = process.argv[2] || process.env.PORT || 3000;
+const basePort = Number(process.argv[2] || process.env.PORT || 3000);
 
 // Serve static files from the current directory
 // Serve all files in this directory
 app.use(express.static(path.join(__dirname)));
 
-app.listen(PORT, () => {
-    console.log(`Server running at http://localhost:${PORT}`);
-});
+// Helper function to open the browser in a cross-platform way
+function openBrowser(url) {
+    const command = process.platform === 'darwin'
+        ? 'open'
+        : process.platform === 'win32'
+            ? 'start'
+            : 'xdg-open';
+    exec(`${command} ${url}`);
+}
+
+// Start the server on the first available port and open the browser
+async function startServer() {
+    try {
+        // portfinder will scan from basePort upwards until it finds a free port
+        const port = await portfinder.getPortPromise({ port: basePort });
+        app.listen(port, () => {
+            console.log(`Server running at http://localhost:${port}`);
+            // Automatically launch the default browser to the server URL
+            openBrowser(`http://localhost:${port}`);
+        });
+    } catch (err) {
+        console.error('Failed to start server:', err);
+    }
+}
+
+startServer();


### PR DESCRIPTION
## Summary
- auto-detect open port if default is busy
- open browser when the server starts
- document new behavior in README and docs

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(started on default port)*
- `node server.js` while another server occupied port 3000 *(started on next port)*

------
https://chatgpt.com/codex/tasks/task_e_68828308a0988328bcddc28d788700c5